### PR TITLE
Add: Pingdom filter tag and home page like others exporters

### DIFF
--- a/cmd/pingdom-exporter/main.go
+++ b/cmd/pingdom-exporter/main.go
@@ -20,6 +20,8 @@ var (
 	VERSION string
 
 	token             string
+	tags              string
+	metricsPath       string
 	waitSeconds       int
 	port              int
 	outageCheckPeriod int
@@ -84,6 +86,8 @@ func init() {
 	flag.IntVar(&port, "port", 9158, "port to listen on")
 	flag.IntVar(&outageCheckPeriod, "outage-check-period", 7, "time (in days) in which to retrieve outage data from the Pingdom API")
 	flag.Float64Var(&defaultUptimeSLO, "default-uptime-slo", 99.0, "default uptime SLO to be used when the check doesn't provide a uptime SLO tag (i.e. uptime_slo_999 to 99.9% uptime SLO)")
+	flag.StringVar(&metricsPath, "web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+	flag.StringVar(&tags, "tags", "", "tag list separated by commas")
 }
 
 type pingdomCollector struct {
@@ -108,6 +112,7 @@ func (pc pingdomCollector) Collect(ch chan<- prometheus.Metric) {
 
 	checks, err := pc.client.Checks.List(map[string]string{
 		"include_tags": "true",
+		"tags":         pc.client.Tags,
 	})
 
 	if err != nil {
@@ -279,6 +284,7 @@ func main() {
 
 	client, err := pingdom.NewClientWithConfig(pingdom.ClientConfig{
 		Token: token,
+		Tags:  tags,
 	})
 
 	if err != nil {
@@ -297,7 +303,16 @@ func main() {
 		prometheus.NewGoCollector(),
 	)
 
-	http.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	http.Handle(metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+             <head><title>Pingdom Exporter</title></head>
+             <body>
+             <h1>bbox Exporter</h1>
+             <p><a href='` + metricsPath + `'>Metrics</a></p>
+             </body>
+             </html>`))
+	})
 
 	log.Infof("Pingdom Exporter %s listening on http://0.0.0.0:%d\n", VERSION, port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))

--- a/cmd/pingdom-exporter/main.go
+++ b/cmd/pingdom-exporter/main.go
@@ -308,7 +308,7 @@ func main() {
 		w.Write([]byte(`<html>
              <head><title>Pingdom Exporter</title></head>
              <body>
-             <h1>bbox Exporter</h1>
+             <h1>Pingdom Exporter</h1>
              <p><a href='` + metricsPath + `'>Metrics</a></p>
              </body>
              </html>`))

--- a/cmd/pingdom-exporter/main.go
+++ b/cmd/pingdom-exporter/main.go
@@ -86,7 +86,7 @@ func init() {
 	flag.IntVar(&port, "port", 9158, "port to listen on")
 	flag.IntVar(&outageCheckPeriod, "outage-check-period", 7, "time (in days) in which to retrieve outage data from the Pingdom API")
 	flag.Float64Var(&defaultUptimeSLO, "default-uptime-slo", 99.0, "default uptime SLO to be used when the check doesn't provide a uptime SLO tag (i.e. uptime_slo_999 to 99.9% uptime SLO)")
-	flag.StringVar(&metricsPath, "web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+	flag.StringVar(&metricsPath, "metrics-path", "/metrics", "path under which to expose metrics")
 	flag.StringVar(&tags, "tags", "", "tag list separated by commas")
 }
 

--- a/pkg/pingdom/pingdom.go
+++ b/pkg/pingdom/pingdom.go
@@ -20,6 +20,8 @@ type Client struct {
 	BaseURL *url.URL
 	client  *http.Client
 
+	Tags string
+
 	Checks        *CheckService
 	OutageSummary *OutageSummaryService
 }
@@ -27,6 +29,7 @@ type Client struct {
 // ClientConfig represents a configuration for a pingdom client.
 type ClientConfig struct {
 	Token      string
+	Tags       string
 	BaseURL    string
 	HTTPClient *http.Client
 }
@@ -46,6 +49,7 @@ func NewClientWithConfig(config ClientConfig) (*Client, error) {
 
 	c := &Client{
 		Token:   config.Token,
+		Tags:    config.Tags,
 		BaseURL: baseURL,
 	}
 


### PR DESCRIPTION
- Add a home page like some Prometheus with a link to `/metrics`
- Add an argument to use Pingdom tags on check requests.

We use Pingdom tags to separate our customers. With that option we can retrieve only metrics for a customer.