### PR TITLE
Introduce 'status' label into metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 AS build
+FROM golang:1.22 AS build
 
 WORKDIR /app
 ADD . .

--- a/cmd/pingdom-exporter/main.go
+++ b/cmd/pingdom-exporter/main.go
@@ -42,13 +42,13 @@ var (
 	pingdomCheckStatusDesc = prometheus.NewDesc(
 		"pingdom_uptime_status",
 		"The current status of the check (1: up, 0: down)",
-		[]string{"id", "name", "hostname", "resolution", "paused", "tags"}, nil,
+		[]string{"id", "name", "hostname", "status", "resolution", "paused", "tags"}, nil,
 	)
 
 	pingdomCheckResponseTimeDesc = prometheus.NewDesc(
 		"pingdom_uptime_response_time_seconds",
 		"The response time of last test, in seconds",
-		[]string{"id", "name", "hostname", "resolution", "paused", "tags"}, nil,
+		[]string{"id", "name", "hostname", "status", "resolution", "paused", "tags"}, nil,
 	)
 
 	pingdomOutagesDesc = prometheus.NewDesc(
@@ -165,6 +165,7 @@ func (pc pingdomCollector) Collect(ch chan<- prometheus.Metric) {
 			id,
 			check.Name,
 			check.Hostname,
+			check.Status,
 			resolution,
 			paused,
 			tags,
@@ -177,6 +178,7 @@ func (pc pingdomCollector) Collect(ch chan<- prometheus.Metric) {
 			id,
 			check.Name,
 			check.Hostname,
+			check.Status,
 			resolution,
 			paused,
 			tags,


### PR DESCRIPTION
The Pingdom API has a 'status' property, enabling visibility of the current status of a check. This could include statuses such as "up", "down", "unconfirmed_down", "unknown", "paused".

We encountered a problem with the metrics wherein a check, after being paused, would transition to 'unknown' status. Because this status does not explicitly indicate that the check is 'up', the 'pingdom_uptime_status' metrics would return a 0 value, without any possibility to discern the specific reason for this value.

Please see this snippet of code for a deeper understanding: 
https://github.com/jusbrasil/pingdom-exporter/blob/24526d56c2c850f7dded150be73ecc107fa785c3/cmd/pingdom-exporter/main.go#L153-L159

In response, this Pull Request (PR) introduces a 'status' label into the following metrics:
- pingdom_uptime_status
- pingdom_uptime_response_time_seconds

As this label mirrors the value from the Pingdom API, it equips us with the ability to further filter out checks in the 'unconfirmed_down' or 'unknown' states, which would otherwise return a 0 value, without affecting the default behavior of existing implementations.