### PR TITLE
Add `pingdom_min_request_limit` internal metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,18 @@ on how to build your own image and push it to your private registry.
 
 ## Exported Metrics
 
-| Metric Name                                         | Description                                                                     |
-| --------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `pingdom_up`                                        | Was the last query on Pingdom API successful                                    |
-| `pingdom_uptime_status`                             | The current status of the check (1: up, 0: down)                                |
-| `pingdom_uptime_response_time_seconds`              | The response time of last test, in seconds                                      |
-| `pingdom_slo_period_seconds`                        | Outage check period, in seconds (see `-outage-check-period` flag)               |
-| `pingdom_outages_total`                             | Number of outages within the outage check period                                |
-| `pingdom_down_seconds`                              | Total down time within the outage check period, in seconds                      |
-| `pingdom_up_seconds`                                | Total up time within the outage check period, in seconds                        |
-| `pingdom_uptime_slo_error_budget_total_seconds`     | Maximum number of allowed downtime, in seconds, according to the uptime SLO     |
-| `pingdom_uptime_slo_error_budget_available_seconds` | Number of seconds of downtime we can still have without breaking the uptime SLO |
+| Metric Name                                         | Description                                                                                                      |
+| --------------------------------------------------- |------------------------------------------------------------------------------------------------------------------|
+| `pingdom_up`                                        | Was the last query on Pingdom API successful                                                                     |
+| `pingdom_uptime_response_time_seconds`              | The minimum remaining requests allowed before hitting the short-term or long-term rate limit in the Pingdom API. |
+| `pingdom_uptime_status`                             | The current status of the check (1: up, 0: down)                                                                 |
+| `pingdom_uptime_response_time_seconds`              | The response time of last test, in seconds                                                                       |
+| `pingdom_slo_period_seconds`                        | Outage check period, in seconds (see `-outage-check-period` flag)                                                |
+| `pingdom_outages_total`                             | Number of outages within the outage check period                                                                 |
+| `pingdom_down_seconds`                              | Total down time within the outage check period, in seconds                                                       |
+| `pingdom_up_seconds`                                | Total up time within the outage check period, in seconds                                                         |
+| `pingdom_uptime_slo_error_budget_total_seconds`     | Maximum number of allowed downtime, in seconds, according to the uptime SLO                                      |
+| `pingdom_uptime_slo_error_budget_available_seconds` | Number of seconds of downtime we can still have without breaking the uptime SLO                                  |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -61,18 +61,18 @@ on how to build your own image and push it to your private registry.
 
 ## Exported Metrics
 
-| Metric Name                                         | Description                                                                                                      |
-| --------------------------------------------------- |------------------------------------------------------------------------------------------------------------------|
-| `pingdom_up`                                        | Was the last query on Pingdom API successful                                                                     |
-| `pingdom_uptime_response_time_seconds`              | The minimum remaining requests allowed before hitting the short-term or long-term rate limit in the Pingdom API. |
-| `pingdom_uptime_status`                             | The current status of the check (1: up, 0: down)                                                                 |
-| `pingdom_uptime_response_time_seconds`              | The response time of last test, in seconds                                                                       |
-| `pingdom_slo_period_seconds`                        | Outage check period, in seconds (see `-outage-check-period` flag)                                                |
-| `pingdom_outages_total`                             | Number of outages within the outage check period                                                                 |
-| `pingdom_down_seconds`                              | Total down time within the outage check period, in seconds                                                       |
-| `pingdom_up_seconds`                                | Total up time within the outage check period, in seconds                                                         |
-| `pingdom_uptime_slo_error_budget_total_seconds`     | Maximum number of allowed downtime, in seconds, according to the uptime SLO                                      |
-| `pingdom_uptime_slo_error_budget_available_seconds` | Number of seconds of downtime we can still have without breaking the uptime SLO                                  |
+| Metric Name                                         | Description                                                                                              |
+| --------------------------------------------------- |----------------------------------------------------------------------------------------------------------|
+| `pingdom_up`                                        | Was the last query on Pingdom API successful                                                             |
+| `pingdom_rate_limit_remaining_requests`             | The remaining requests allowed before hitting the short-term or long-term rate limit in the Pingdom API. |
+| `pingdom_uptime_status`                             | The current status of the check (1: up, 0: down)                                                         |
+| `pingdom_uptime_response_time_seconds`              | The response time of last test, in seconds                                                               |
+| `pingdom_slo_period_seconds`                        | Outage check period, in seconds (see `-outage-check-period` flag)                                        |
+| `pingdom_outages_total`                             | Number of outages within the outage check period                                                         |
+| `pingdom_down_seconds`                              | Total down time within the outage check period, in seconds                                               |
+| `pingdom_up_seconds`                                | Total up time within the outage check period, in seconds                                                 |
+| `pingdom_uptime_slo_error_budget_total_seconds`     | Maximum number of allowed downtime, in seconds, according to the uptime SLO                              |
+| `pingdom_uptime_slo_error_budget_available_seconds` | Number of seconds of downtime we can still have without breaking the uptime SLO                          |
 
 ## Development
 

--- a/cmd/pingdom-exporter/main.go
+++ b/cmd/pingdom-exporter/main.go
@@ -33,9 +33,9 @@ var (
 		nil, nil,
 	)
 
-	pingdomMinRequestLimitDesc = prometheus.NewDesc(
-		"pingdom_rate_limit_min_remaining_requests",
-		"Tracks the minimum remaining requests allowed before hitting the short-term or long-term rate limit in the Pingdom API.",
+	pingdomRateLimitRemainingRequestsDesc = prometheus.NewDesc(
+		"pingdom_rate_limit_remaining_requests",
+		"Tracks the remaining requests allowed before hitting the short-term or long-term rate limit in the Pingdom API.",
 		nil, nil,
 	)
 
@@ -102,7 +102,7 @@ type pingdomCollector struct {
 
 func (pc pingdomCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- pingdomUpDesc
-	ch <- pingdomMinRequestLimitDesc
+	ch <- pingdomRateLimitRemainingRequestsDesc
 	ch <- pingdomOutageCheckPeriodDesc
 	ch <- pingdomCheckStatusDesc
 	ch <- pingdomCheckResponseTimeDesc
@@ -123,7 +123,7 @@ func (pc pingdomCollector) Collect(ch chan<- prometheus.Metric) {
 	})
 
 	ch <- prometheus.MustNewConstMetric(
-		pingdomMinRequestLimitDesc,
+		pingdomRateLimitRemainingRequestsDesc,
 		prometheus.GaugeValue,
 		minReqLimit,
 	)

--- a/cmd/pingdom-exporter/main.go
+++ b/cmd/pingdom-exporter/main.go
@@ -33,6 +33,12 @@ var (
 		nil, nil,
 	)
 
+	pingdomMinRequestLimit = prometheus.NewDesc(
+		"pingdom_min_request_limit",
+		"Minimal request limit from both Req-Limit-Short and Req-Limit-Long",
+		nil, nil,
+	)
+
 	pingdomOutageCheckPeriodDesc = prometheus.NewDesc(
 		"pingdom_slo_period_seconds",
 		"Outage check period, in seconds",
@@ -96,6 +102,7 @@ type pingdomCollector struct {
 
 func (pc pingdomCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- pingdomUpDesc
+	ch <- pingdomMinRequestLimit
 	ch <- pingdomOutageCheckPeriodDesc
 	ch <- pingdomCheckStatusDesc
 	ch <- pingdomCheckResponseTimeDesc
@@ -110,10 +117,16 @@ func (pc pingdomCollector) Collect(ch chan<- prometheus.Metric) {
 	outageCheckPeriodDuration := time.Hour * time.Duration(24*outageCheckPeriod)
 	outageCheckPeriodSecs := float64(outageCheckPeriodDuration / time.Second)
 
-	checks, err := pc.client.Checks.List(map[string]string{
+	checks, minReqLimit, err := pc.client.Checks.List(map[string]string{
 		"include_tags": "true",
 		"tags":         pc.client.Tags,
 	})
+
+	ch <- prometheus.MustNewConstMetric(
+		pingdomMinRequestLimit,
+		prometheus.GaugeValue,
+		minReqLimit,
+	)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error getting checks: %v", err)

--- a/cmd/pingdom-exporter/main.go
+++ b/cmd/pingdom-exporter/main.go
@@ -33,9 +33,9 @@ var (
 		nil, nil,
 	)
 
-	pingdomMinRequestLimit = prometheus.NewDesc(
-		"pingdom_min_request_limit",
-		"Minimal request limit from both Req-Limit-Short and Req-Limit-Long",
+	pingdomMinRequestLimitDesc = prometheus.NewDesc(
+		"pingdom_rate_limit_min_remaining_requests",
+		"Tracks the minimum remaining requests allowed before hitting the short-term or long-term rate limit in the Pingdom API.",
 		nil, nil,
 	)
 
@@ -102,7 +102,7 @@ type pingdomCollector struct {
 
 func (pc pingdomCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- pingdomUpDesc
-	ch <- pingdomMinRequestLimit
+	ch <- pingdomMinRequestLimitDesc
 	ch <- pingdomOutageCheckPeriodDesc
 	ch <- pingdomCheckStatusDesc
 	ch <- pingdomCheckResponseTimeDesc
@@ -123,7 +123,7 @@ func (pc pingdomCollector) Collect(ch chan<- prometheus.Metric) {
 	})
 
 	ch <- prometheus.MustNewConstMetric(
-		pingdomMinRequestLimit,
+		pingdomMinRequestLimitDesc,
 		prometheus.GaugeValue,
 		minReqLimit,
 	)

--- a/pkg/pingdom/check.go
+++ b/pkg/pingdom/check.go
@@ -3,6 +3,18 @@ package pingdom
 import (
 	"encoding/json"
 	"io/ioutil"
+	"math"
+	"net/http"
+	"regexp"
+	"strconv"
+)
+
+var (
+	reqLimitHeaderKeys = []string{
+		"req-limit-short",
+		"req-limit-long",
+	}
+	reqLimitRe = regexp.MustCompile(`Remaining: (\d+) Time until reset: (\d+)`)
 )
 
 // CheckService provides an interface to Pingdom checks.
@@ -13,24 +25,26 @@ type CheckService struct {
 // List returns a list of checks from Pingdom.
 // This returns type CheckResponse rather than Check since the
 // Pingdom API does not return a complete representation of a check.
-func (cs *CheckService) List(params ...map[string]string) ([]CheckResponse, error) {
+func (cs *CheckService) List(params ...map[string]string) ([]CheckResponse, float64, error) {
 	param := map[string]string{}
 	if len(params) == 1 {
 		param = params[0]
 	}
 	req, err := cs.client.NewRequest("GET", "/checks", param)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	resp, err := cs.client.client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
 
+	minRequestLimit := minRequestLimitFromHeader(resp.Header)
+
 	if err := validateResponse(resp); err != nil {
-		return nil, err
+		return nil, minRequestLimit, err
 	}
 
 	bodyBytes, _ := ioutil.ReadAll(resp.Body)
@@ -38,5 +52,21 @@ func (cs *CheckService) List(params ...map[string]string) ([]CheckResponse, erro
 	m := &listChecksJSONResponse{}
 	err = json.Unmarshal([]byte(bodyString), &m)
 
-	return m.Checks, err
+	return m.Checks, minRequestLimit, err
+}
+
+func minRequestLimitFromHeader(header http.Header) float64 {
+	minRequestLimit := math.MaxFloat64
+
+	for _, key := range reqLimitHeaderKeys {
+		matches := reqLimitRe.FindStringSubmatch(header.Get(key))
+		if len(matches) > 0 {
+			limit, err := strconv.ParseFloat(matches[1], 64)
+			if err == nil && limit < minRequestLimit {
+				minRequestLimit = limit
+			}
+		}
+	}
+
+	return minRequestLimit
 }


### PR DESCRIPTION
Add `pingdom_min_request_limit` internal metric, which returns the minimal value of reaming requests from [`Req-Limit-Short` and `Req-Limit-Long` headers](https://docs.pingdom.com/api/#section/Limits). This will allow to monitor the remaining request limit to take action before the API rate limits a token or whole account.